### PR TITLE
=silence download dialog

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 Gumbo
 Cascadia
 AbstractTrees
+Suppressor

--- a/src/DataDepsGenerators.jl
+++ b/src/DataDepsGenerators.jl
@@ -1,5 +1,6 @@
 module DataDepsGenerators
 using Gumbo, Cascadia, AbstractTrees
+using Suppressor
 
 export generate, UCI
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,12 +1,12 @@
 
 
+
 """
     getpage(url)
 
 downloads and parses the page from the URL
 """
-getpage(url) = parsehtml(readstring(download(url)))
-
+getpage(url) = parsehtml(readstring(@suppress(download(url))))
 
 """
     text_only(doc)


### PR DESCRIPTION
I think having the download bars show up is un-useful.
It is downloading simple single pages so finishes faster than it can print.

The bars will make it harder to copy paste output.

They also might confuse users who think it is the data itself being downloaded.
Rather than websites while we look for the data URLS