### PR TITLE
A dataset is not a paper

### DIFF
--- a/src/DataCite.jl
+++ b/src/DataCite.jl
@@ -20,7 +20,7 @@ function description(repo::DataCite, mainpage)
 
     $(desc)
 
-    Please cite this paper:
+    Please cite this work:
     $(paper)
     if you use this in your research.
     """, "\$")


### PR DESCRIPTION
Spotted this on the way when checking something.
We should be careful when we generate a citation for something,
to only call it a paper if it is a journal paper, a conference paper or similar.
If it is a dataset (or something else) we can call it a "work".

I wonder is it possible to get out of DataCite the associated paper, (where it exists)?
Like we do for DataDryad.
I know Cross-Ref was keen to link their data dois to paper dois