### PR TITLE
Correct figshare example

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ FigShare is a popular website for sharing figures and data.
 
 Example of use:
 ```julia
-    generate(Figshare(), "10.5281/zenodo.1194927")
+    generate(Figshare(), "10.1371/journal.pbio.2001414")
     generate(Figshare(), "https://figshare.com/articles/Youth_Activism_in_Chile_from_urban_educational_inequalities_to_experiences_of_living_together_and_solidarity/6504206")
 ```
 


### PR DESCRIPTION
Partially fixes #67

The example for figshare that was used previously simply does not exist on figshare.
I am not sure if it was there previously, but it isn't now.
I think it was maybe a mistake previously, a miss-copy.

This PR replaces it with one that we test