### PR TITLE
Handle not having a list of URLS but just one (support PANGAEA)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = "data"
 authors = ["oxinabox <oxinabox@ucc.asn.au>", "SebastinSanty <sebastinssanty@gmail.com>"]
 description = "Generating registration blocks for DataDeps.jl in one key press"
 repository = "https://github.com/oxinabox/DataDepsGenerators.jl.git"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -14,7 +14,13 @@ Gumbo = "708ec375-b3d6-5a57-a7ce-8257bf98657a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
+
+[compat]
+AbstractTrees = "0.3.3"
+Cascadia = "1.0.0"
+Gumbo = "0.8.0"
+HTTP = "0.8.17"
+JSON = "0.21.0"
 
 [extras]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-Gumbo 0.4.1
-Cascadia
-AbstractTrees
-JSON
-HTTP

--- a/src/APIs/JSONLD/JSONLD.jl
+++ b/src/APIs/JSONLD/JSONLD.jl
@@ -43,6 +43,9 @@ function license(::JSONLD, mainpage)
     if license isa Dict
         license = getfirst(license, "url", "text")
     end
+    if license isa AbstractVector
+        license = first(license)
+    end
     filter_html(license)
 end
 

--- a/src/APIs/JSONLD/JSONLD.jl
+++ b/src/APIs/JSONLD/JSONLD.jl
@@ -49,6 +49,9 @@ end
 
 function get_urls(repo::JSONLD, page)
     lift(getfirst(page, "distribution")) do url_list
+        if url_list isa AbstractDict  # sometimes it is just 1 dict.
+            url_list = (url_list,)  # make it a collection
+        end
         urls = collect(skipmissing(getfirst.(url_list, "contentUrl")))
     end
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-ReferenceTests v0.3.0
-DataDeps
-MD5

--- a/test/citation_generation.jl
+++ b/test/citation_generation.jl
@@ -4,7 +4,5 @@ using Test
 @test remove_cite_version(citation_text("10.3732/ajb.1000481")) ==
     "Smith, S. A., Beaulieu, J. M., Stamatakis, A., & Donoghue, M. J. (2011). Understanding angiosperm diversification using small and large phylogenetic trees. American Journal of Botany, 98(3), 404–414. doi:10.3732/ajb.1000481"
 
-
-
-@test remove_cite_version(citation_text("https://doi.org/10.5061/dryad.8790")) ==
+@test_broken remove_cite_version(citation_text("https://doi.org/10.5061/dryad.8790")) ==
     "Smith, S. A., Beaulieu, J. M., Stamatakis, A., & Donoghue, M. J. (2011). Data from: Understanding angiosperm diversification using small and large phylogenetic trees [Data set]. Dryad Digital Repository. https://doi.org/10.5061/dryad.8790"


### PR DESCRIPTION
Closes #76  @briochemc  

I thought we should already havee PANGAEA support form one of the generic supports we have,
and we almost did.
It has JSON-LD, but its not quite following the structure we expected.

Demonstration:

```julia
julia> generate("https://doi.pangaea.de/10.1594/PANGAEA.921913") |> println
register(DataDep(
    "Benthic foraminiferal stable isotopes, planktonic foraminiferal biostratigraphy and seismic profiles for IODP Site 356-U1463",
    """
        Dataset: Benthic foraminiferal stable isotopes, planktonic foraminiferal biostratigraphy and seismic profiles for IODP Site 356-U1463
        Website: https://doi.pangaea.de/10.1594/PANGAEA.921913
        Author: Jeroen Groeneveld et al.
        Date of Publication: August 24, 2020

        Determining the age of marine sediments is essential to reconstruct past changes in oceanography and climate. The oxygen isotopes of benthic foraminifera record long-term changes in global ice volume and deep-water temperature, and are commonly used to construct age models. However, continental margin settings often display much higher sedimentation rates due to regional input by rivers. Here, it is necessary to create a regional framework to allow precise dating of strata. We created such a framework for the Northwest Shelf (NWS) of Australia, which was cored by International Ocean Discovery Program (IODP) Expedition 356. We used oxygen and carbon isotopes in benthic foraminifera to construct an astronomically-tuned age model for IODP Site U1463. The natural gamma radiation (NGR) variations for IODP Site U1463 were then correlated to those of other IODP sites and industry wells in the area. […]
        """,
        ["https://doi.pangaea.de/10.1594/PANGAEA.921913?format=zip"],
))
```